### PR TITLE
Enable FusionDirectory password recovery for users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM node:5.2.0
 RUN export DEBIAN_FRONTEND=noninteractive && \
     export LC_ALL=en_US.UTF-8 && \
-    echo deb http://apt.dockerproject.org/repo debian-jessie main >> /etc/apt/sources.list && \
-    apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
+    echo "deb http://httpredir.debian.org/debian jessie contrib" >> /etc/apt/sources.list && \
+    apt-get update && apt-get install -y apt-transport-https ca-certificates curl software-properties-common && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
     apt-get update && \
-    apt-get install -y docker-engine && \
+    apt-get install -y docker-ce && \
     rm -rf /var/lib/apt/lists/* && \
     curl -L https://github.com/docker/compose/releases/download/1.5.2/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose
 COPY package.json /shasoco/package.json

--- a/build-image
+++ b/build-image
@@ -8,4 +8,4 @@ fi
 
 VERSION=`cat package.json|grep \"version\"|cut -d\" -f4`
 docker build -t shasoco/shasoco:latest .
-docker tag -f shasoco/shasoco:latest shasoco/shasoco:$VERSION
+docker tag shasoco/shasoco:latest shasoco/shasoco:$VERSION

--- a/compose/ldap.yml
+++ b/compose/ldap.yml
@@ -11,6 +11,7 @@ directory:
     restart: always
     links:
      - ldap
+     - smtp
     environment:
      - "VIRTUAL_HOST=http://directory.<%=httpHost%>,https://directory.<%=httpsHost%>"
      - SSL_CERT=<%-sslcert%>
@@ -19,6 +20,19 @@ directory:
      - LDAP_DOMAIN=<%=domain%>
      - LDAP_PASSWORD=<%=rootpassword%>
      - FUSIONDIRECTORY_PASSWORD=<%=adminpassword%>
+
+     - SMTP_ENABLED=true
+     - SMTP_DOMAIN=<%=domain%>
+     - SMTP_HOST=smtp
+     - SMTP_PORT=25
+     - SMTP_AUTHENTICATION=plain
+     - SMTP_USER=mailer@<%=domain%>
+     - SMTP_PASS=<%=adminpassword%>
+     - SMTP_TLS=off
+     - SMTP_STARTTLS=off
+     - SMTP_TLSCERTCHECK=off
+     - SMTP_MAILDOMAIN=<%=domain%>
+
     volumes_from:
      - ldapdata
 

--- a/compose/ldap.yml
+++ b/compose/ldap.yml
@@ -6,7 +6,7 @@
 #
 
 directory:
-    image: shasoco/fusiondirectory:1.0.9.1
+    image: jeritiana/fusiondirectory:1.0.9.3
     hostname: directory.<%=domain%>
     restart: always
     links:
@@ -23,7 +23,7 @@ directory:
      - ldapdata
 
 ldap:
-    image: shasoco/openldap:2.4.40
+    image: jeritiana/openldap:2.4.40
     hostname: ldap.<%=domain%>
     restart: always
     volumes_from:

--- a/lib/services.js
+++ b/lib/services.js
@@ -1,6 +1,6 @@
 module.exports = [
-    require('./service/ldap'),
     require('./service/smtp'),
+    require('./service/ldap'),
     require('./service/vault'),
     require('./service/redmine'),
     require('./service/wordpress'),


### PR DESCRIPTION
Actually, this PR contains three things which are all related:
* Update Docker installation on Debian (otherwise the image cannot be rebuilt)
* Update FusionDirectory version to have a successful builds
* Enable the SMTP configuration in the directory service

This PR depends both on https://github.com/shasoco/fusiondirectory/pull/1 and https://github.com/shasoco/openldap/pull/1. The used docker images could then be reverted back from `jeritiana` to `shasoco`.